### PR TITLE
Fix tests for windows-latest

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,8 @@ good-names=_,i,j,k,e,ex,cm,fh
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=missing-module-docstring,
+disable=duplicate-code,
+        missing-module-docstring,
         unidiomatic-typecheck,
         too-few-public-methods,
         too-many-arguments

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 
 ## Run tests
 test:
-	nosetests --rednose
+	nosetests --rednose test/*.py
 
 ## Prepare a build
 build:

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ contents:
   .bashrc:
   .clibato.yml:
 destination:
-  type: "directory"
-  path: "~/backup/clibato"
+  type: 'directory'
+  path: '~/backup/clibato'
 ```
 
 ### Backup to a Git repository
@@ -86,8 +86,8 @@ contents:
   .bashrc:
   .clibato.yml:
 destination:
-  type: "repository"
-  path: "~/backup/clibato"
-  remote: "git@gitlab.com:jigarius/dotfiles.git"
+  type: 'repository'
+  path: '~/backup/clibato'
+  remote: 'git@gitlab.com:jigarius/dotfiles.git'
   branch: 'main'
 ```

--- a/clibato/__init__.py
+++ b/clibato/__init__.py
@@ -18,7 +18,7 @@ class Clibato:
     """Clibato Controller"""
 
     ROOT = Path(__file__).parent.parent
-    VERSION = "0.9.0"
+    VERSION = "1.0.0.b1"
 
     def __init__(self):
         self._args = None

--- a/clibato/__init__.py
+++ b/clibato/__init__.py
@@ -90,6 +90,9 @@ class Clibato:
         :return: A Config object.
         """
         path = Config.locate(self._args.config_path)
+        if path is None:
+            raise ConfigError(f'Configuration not found: {self._args.config_path}')
+
         return Config.from_file(path)
 
     def _init_logger(self) -> None:

--- a/clibato/config.py
+++ b/clibato/config.py
@@ -65,7 +65,7 @@ class Config:
         )
 
     @staticmethod
-    def from_file(path):
+    def from_file(path: Path):
         """
         Create Config object from a YAML file.
 
@@ -75,11 +75,13 @@ class Config:
         :return: A Config object.
         """
         logger.info('Loading configuration: %s', path)
-        with open(path, 'r') as stream:
-            try:
-                data = yaml.safe_load(stream)
-            except yaml.YAMLError as error:
-                raise ConfigError(error) from error
+
+        try:
+            data = open(str(path), 'r').read()
+            logger.debug(data)
+            data = yaml.safe_load(data)
+        except yaml.YAMLError as error:
+            raise ConfigError(error) from error
 
         return Config.from_dict(data)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         "Tracker": "https://github.com/jigarius/clibato/issues"
     },
     packages=setuptools.find_packages(exclude=['test']),
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=install_requires,
     entry_points={
         'console_scripts': ['clibato=clibato.__main__:main'],

--- a/test/support.py
+++ b/test/support.py
@@ -17,15 +17,18 @@ class TestCase(unittest.TestCase):
     def __init__(self, *args):
         super().__init__(*args)
         self._fixtures = None
-        self._source_path = None
-        self._backup_path = None
+
+    def setUp(self) -> None:
+        self._fixtures = []
 
     def tearDown(self) -> None:
-        # Temporary objects will automatically be cleaned once all existing
-        # references are removed.
+        for fixture in self._fixtures:
+            path = Path(fixture.name)
+            if path.is_file():
+                path.unlink()
+
+        # TemporaryDirectory will be deleted when no references exist.
         self._fixtures = None
-        self._source_path = None
-        self._backup_path = None
 
     @staticmethod
     @contextmanager
@@ -121,18 +124,20 @@ class TestCase(unittest.TestCase):
         """
         self.assertMultiLineEqual(expected, real.replace('\r\n', '\n'))
 
-    @staticmethod
-    def create_clibato_config(data: dict) -> NamedTemporaryFile():
+    def create_clibato_config(self, data: dict) -> str:
         """
         Creates a temporary YAML containing the provided config.
 
         :param data: Configuration as a dictionary
-        :return: NamedTemporaryFile
+        :return: Path to a temporary config file.
         """
-        config_file = NamedTemporaryFile(suffix='.clibato.yml')
-        with open(config_file.name, 'w') as fh:
-            yaml.dump(data, fh)
-        return config_file
+        file = NamedTemporaryFile('w', suffix='.clibato.yml', delete=False)
+        file.write(yaml.safe_dump(data))
+        file.close()
+
+        self._fixtures.append(file)
+
+        return file.name
 
     def create_file_fixtures(self, location: str) -> Tuple[Path, Path]:
         """
@@ -145,11 +150,6 @@ class TestCase(unittest.TestCase):
         :param location: One of "source" or "backup".
         :return: Paths to 2 directories: source_path and backup_path.
         """
-        if self._fixtures is not None:
-            raise RuntimeError('Fixtures can only be created once.')
-
-        self._fixtures = []
-
         source_dir = TemporaryDirectory()
         self._fixtures.append(source_dir)
         source_path = Path(source_dir.name)

--- a/test/support.py
+++ b/test/support.py
@@ -111,6 +111,16 @@ class TestCase(unittest.TestCase):
         self.assert_file_exists(path)
         self.assertEqual(contents, path.read_text())
 
+    def assert_output(self, expected, real):
+        """
+        Asserts console output equality, removing \r.
+
+        :param expected: Expected output.
+        :param real: Real output.
+        :return: None
+        """
+        self.assertMultiLineEqual(expected, real.replace('\r\n', '\n'))
+
     @staticmethod
     def create_clibato_config(data: dict) -> NamedTemporaryFile():
         """

--- a/test/support.py
+++ b/test/support.py
@@ -60,8 +60,12 @@ class TestCase(unittest.TestCase):
         :param level: Expected level name, e.g. INFO, WARNING, ERROR.
         :return: None
         """
-        expectation = {'level': level, 'message': message}
-        real = {'level': record.levelname, 'message': record.message}
+        expectation = f'{level}: {message}'
+        real = f'{record.levelname}: {record.message}'
+
+        # For some reason, Windows path-separator gets escaped twice?
+        if os.name == 'nt':
+            real = real.replace('\\\\', '\\')
 
         self.assertEqual(expectation, real, 'Log record mismatch')
 

--- a/test/test_clibato.py
+++ b/test/test_clibato.py
@@ -1,7 +1,6 @@
 from contextlib import redirect_stdout
 from io import StringIO
 import logging
-from os import linesep
 from pathlib import Path
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 from clibato import Clibato
@@ -65,7 +64,7 @@ class TestClibato(TestCase):
             app = Clibato()
             app.execute(['init', '-c', str(config_path)])
 
-        expected = linesep.join([
+        expected = '\n'.join([
             f'Configuration created: {config_path.resolve()}',
             '',
             'Modify the file as per your requirements.',
@@ -140,20 +139,20 @@ class TestClibato(TestCase):
 
         with self.assertLogs('clibato', logging.INFO) as cm, redirect_stdout(StringIO()) as output:
             app = Clibato()
-            app.execute(['restore', '-v', '-c', config_file.name])
+            app.execute(['restore', '-v', '-c', config_path])
 
         self.assert_length(cm.records, 3)
         self.assert_log_record(
             cm.records[0],
             level='INFO',
-            message=f'Loading configuration: {config_file.name}'
+            message=f'Loading configuration: {config_path}'
         )
 
         self.assert_file_contents(source_path / self.BUNNY_PATH, 'I am a bunny')
         self.assert_file_contents(source_path / self.WABBIT_PATH, 'I am a wabbit')
 
-        expected = linesep.join(['Restore completed.', ''])
-        self.assertEqual(expected, output.getvalue())
+        expected = '\n'.join(['Restore completed.', ''])
+        self.assert_output(expected, output.getvalue())
 
     def test_version(self):
         """Test: clibato version"""
@@ -161,7 +160,7 @@ class TestClibato(TestCase):
             app = Clibato()
             app.execute(['version'])
 
-        self.assertEqual(f'Clibato v{Clibato.VERSION}\n', output.getvalue())
+        self.assert_output(f'Clibato v{Clibato.VERSION}\n', output.getvalue())
 
     def test_version_verbose(self):
         """Test: clibato version --verbose"""
@@ -169,11 +168,11 @@ class TestClibato(TestCase):
             app = Clibato()
             app.execute(['version', '-v'])
 
-        expected = linesep.join([
+        expected = '\n'.join([
             f'Clibato v{Clibato.VERSION}',
             'Author: Jigarius | jigarius.com',
             'GitHub: github.com/jigarius/clibato',
             ''
         ])
 
-        self.assertEqual(expected, output.getvalue())
+        self.assert_output(expected, output.getvalue())

--- a/test/test_clibato.py
+++ b/test/test_clibato.py
@@ -39,6 +39,22 @@ class TestClibato(TestCase):
         args = Clibato.parse_args(['init', '-c', str(config_path)])
         self.assertEqual(config_path, args.config_path)
 
+    def test_config_file_not_found(self):
+        """.execute() shows error when config file can't be located"""
+        config_path = 'missing.config.yml'
+
+        with self.assertLogs('clibato', logging.ERROR) as cm:
+            app = Clibato()
+            result = app.execute(['backup', '-c', str(config_path)])
+
+        self.assertFalse(result)
+        self.assert_length(cm.records, 1)
+        self.assert_log_record(
+            cm.records[0],
+            level='ERROR',
+            message=f'Configuration not found: {config_path}'
+        )
+
     def test_init(self):
         """Test: clibato init -c /path/to/.clibato.yml"""
         config_dir = TemporaryDirectory()

--- a/test/test_clibato.py
+++ b/test/test_clibato.py
@@ -97,7 +97,7 @@ class TestClibato(TestCase):
     def test_backup(self):
         """Test: clibato backup -v -c /path/to/config.yml"""
         source_path, backup_path = self.create_file_fixtures(location='source')
-        config_file = self.create_clibato_config({
+        config_path = self.create_clibato_config({
             'contents': {
                 self.BUNNY_PATH: str(source_path / self.BUNNY_PATH),
                 self.WABBIT_PATH: str(source_path / self.WABBIT_PATH)
@@ -110,25 +110,24 @@ class TestClibato(TestCase):
 
         with self.assertLogs('clibato', logging.INFO) as cm, redirect_stdout(StringIO()) as output:
             app = Clibato()
-            app.execute(['backup', '-v', '-c', config_file.name])
+            app.execute(['backup', '-v', '-c', config_path])
 
         self.assert_length(cm.records, 3)
         self.assert_log_record(
             cm.records[0],
             level='INFO',
-            message=f'Loading configuration: {config_file.name}'
+            message=f'Loading configuration: {config_path}'
         )
 
         self.assert_file_contents(backup_path / self.BUNNY_PATH, 'I am a bunny')
         self.assert_file_contents(backup_path / self.WABBIT_PATH, 'I am a wabbit')
 
-        expected = linesep.join(['Backup completed.', ''])
-        self.assertEqual(expected, output.getvalue())
+        self.assert_output('Backup completed.\n', output.getvalue())
 
     def test_restore(self):
         """Test: clibato restore -v -c /path/to/config.yml"""
         source_path, backup_path = self.create_file_fixtures(location='backup')
-        config_file = self.create_clibato_config({
+        config_path = self.create_clibato_config({
             'contents': {
                 self.BUNNY_PATH: str(source_path / self.BUNNY_PATH),
                 self.WABBIT_PATH: str(source_path / self.WABBIT_PATH)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,8 +1,6 @@
 from shutil import copyfile
 from pathlib import Path
-import os
 import tempfile
-import unittest
 
 from clibato import Clibato, Content, Directory, Config, ConfigError
 from .support import TestCase

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -103,27 +103,33 @@ class TestConfig(TestCase):
             with self.assertRaisesRegex(ConfigError, message):
                 Config.from_dict(data)
 
-    @unittest.skipIf(os.name == 'nt', 'Fixture contains posix paths only')
     def test_from_file(self):
         """.from_file()"""
+        config_path = self.create_clibato_config({
+            'contents': {
+                '.bashrc': None,
+                '.vimrc': None,
+            },
+            'destination': {
+                'type': 'directory',
+                'path': tempfile.gettempdir()
+            }
+        })
+
         with self.assertLogs('clibato') as cm:
             self.assertEqual(
                 Config(
-                    contents=[
-                        Content('.bashrc'),
-                        Content('.zshrc'),
-                        Content('Documents/todo.txt')
-                    ],
-                    destination=Directory(path='/tmp'),
+                    contents=[Content('.bashrc'), Content('.vimrc')],
+                    destination=Directory(path=tempfile.gettempdir()),
                 ),
-                Config.from_file(self._FIXTURE_PATH)
+                Config.from_file(config_path)
             )
 
         self.assert_length(cm.records, 1)
         self.assert_log_record(
             cm.records[0],
             level='INFO',
-            message=f'Loading configuration: {self._FIXTURE_PATH}'
+            message=f'Loading configuration: {config_path}'
         )
 
     def test_from_file_with_non_existent_file(self):

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -58,9 +58,14 @@ class TestContent(unittest.TestCase):
 
     def test_source_path_with_relative_path(self):
         """.new() raises if source_path is relative"""
-        message = 'Source path invalid: Documents/todo.txt'
-        with self.assertRaisesRegex(ConfigError, message):
-            Content('todo.txt', 'Documents/todo.txt')
+        path = Path('Documents', 'todo.txt')
+        with self.assertRaises(ConfigError) as cm:
+            Content('todo.txt', path)
+
+        self.assertEqual(
+            f'Source path invalid: {path}',
+            str(cm.exception).strip("'")
+        )
 
     def test_source_path_when_empty(self):
         """.new() works when source_path is empty"""
@@ -82,9 +87,14 @@ class TestContent(unittest.TestCase):
 
     def test_backup_path_cannot_be_absolute(self):
         """.new() raises if backup path is not absolute"""
-        message = 'Backup path cannot be absolute: /.bashrc'
-        with self.assertRaisesRegex(ConfigError, message):
-            Content(str(Path('/', '.bashrc')))
+        path = str(Path('/', 'Documents', '.bashrc').absolute())
+        with self.assertRaises(ConfigError) as cm:
+            Content(path)
+
+        self.assertEqual(
+            f'Backup path cannot be absolute: {path}',
+            str(cm.exception).strip("'")
+        )
 
     def test_backup_path_cannot_contain_illegal_elements(self):
         """.new() raises if backup path contains illegal elements"""

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -41,7 +41,7 @@ class TestContent(unittest.TestCase):
 
     def test_source_path_with_absolute_path(self):
         """.new() works with absolute source paths"""
-        source_path = Path('/', 'todo.txt')
+        source_path = Path('/', 'todo.txt').absolute()
         subject = Content('todo.txt', str(source_path))
 
         self.assertEqual(source_path, subject.source_path())

--- a/test/test_destination.py
+++ b/test/test_destination.py
@@ -130,12 +130,12 @@ class TestDirectory(TestCase):
         self.assert_log_record(
             cm.records[0],
             level='INFO',
-            message="Backed up: %s" % (source_path / self.BUNNY_PATH)
+            message=f'Backed up: {source_path / self.BUNNY_PATH}'
         )
         self.assert_log_record(
             cm.records[1],
             level='INFO',
-            message="Backed up: %s" % (source_path / self.WABBIT_PATH)
+            message=f'Backed up: {source_path / self.WABBIT_PATH}'
         )
 
         self.assert_file_contents(backup_path / self.BUNNY_PATH, 'I am a bunny')
@@ -157,12 +157,12 @@ class TestDirectory(TestCase):
         self.assert_log_record(
             cm.records[0],
             level='ERROR',
-            message="[Errno 2] No such file or directory: '%s'" % (source_path / skunk_path)
+            message=f"[Errno 2] No such file or directory: '{source_path / skunk_path}'"
         )
         self.assert_log_record(
             cm.records[1],
             level='INFO',
-            message="Backed up: %s" % (source_path / self.WABBIT_PATH)
+            message=f'Backed up: {source_path / self.WABBIT_PATH}'
         )
 
         self.assert_file_not_exists(backup_path / skunk_path)
@@ -183,12 +183,12 @@ class TestDirectory(TestCase):
         self.assert_log_record(
             cm.records[0],
             level='INFO',
-            message="Restored: %s" % (source_path / self.BUNNY_PATH)
+            message=f'Restored: {source_path / self.BUNNY_PATH}'
         )
         self.assert_log_record(
             cm.records[1],
             level='INFO',
-            message="Restored: %s" % (source_path / self.WABBIT_PATH)
+            message=f'Restored: {source_path / self.WABBIT_PATH}'
         )
 
         self.assert_file_contents(source_path / self.BUNNY_PATH, 'I am a bunny')
@@ -210,12 +210,12 @@ class TestDirectory(TestCase):
         self.assert_log_record(
             cm.records[0],
             level='ERROR',
-            message="[Errno 2] No such file or directory: '%s'" % (backup_path / skunk_path)
+            message=f"[Errno 2] No such file or directory: '{backup_path / skunk_path}'"
         )
         self.assert_log_record(
             cm.records[1],
             level='INFO',
-            message="Restored: %s" % (source_path / self.WABBIT_PATH)
+            message=f'Restored: {source_path / self.WABBIT_PATH}'
         )
 
         self.assert_file_not_exists(source_path / skunk_path)

--- a/test/test_destination.py
+++ b/test/test_destination.py
@@ -80,21 +80,30 @@ class TestDirectory(TestCase):
 
     def test_path_cannot_be_empty(self):
         """Path cannot be empty"""
-        message = 'Path cannot be empty'
-        with self.assertRaisesRegex(ConfigError, message):
+        with self.assertRaisesRegex(ConfigError, 'Path cannot be empty'):
             Directory('')
 
     def test_path_must_be_absolute(self):
         """Path must be absolute"""
-        message = 'Path is not absolute: foo/bar'
-        with self.assertRaisesRegex(ConfigError, message):
-            Directory('foo/bar')
+        path = Path('foo', 'bar')
+        with self.assertRaises(ConfigError) as cm:
+            Directory(str(path))
+
+        self.assertEqual(
+            f'Path is not absolute: {path}',
+            str(cm.exception).strip("'")
+        )
 
     def test_path_must_be_directory(self):
         """Path must be a directory that exists"""
-        message = 'Path is not a directory: /tmp/foo'
-        with self.assertRaisesRegex(ConfigError, message):
-            Directory('/tmp/foo')
+        path = Path(gettempdir(), 'foo').resolve()
+        with self.assertRaises(ConfigError) as cm:
+            Directory(path=str(path))
+
+        self.assertEqual(
+            f'Path is not a directory: {path}',
+            str(cm.exception).strip("'")
+        )
 
     def test_path_has_tilde(self):
         """Path can contain tilde (~)"""

--- a/test/test_destination.py
+++ b/test/test_destination.py
@@ -228,7 +228,7 @@ class TestRepository(TestCase):
     def test_new(self):
         """Instance creation."""
         subject = Repository(
-            '/tmp',
+            gettempdir(),
             'git@github.com:jigarius/clibato.git',
             'backup',
             'Jigarius',
@@ -270,7 +270,7 @@ class TestRepository(TestCase):
         """Remote cannot be empty"""
         message = 'Remote cannot be empty'
         with self.assertRaisesRegex(ConfigError, message):
-            Repository('/tmp', '')
+            Repository(gettempdir(), '')
 
     @unittest.skip('TODO')
     def test_backup(self):


### PR DESCRIPTION
As expected, many tests fail on Windows 😞 . In general, these are the causes:

  * Some tests assume posix paths; must use os.path.sep.
  * Tests related to output-testing need to account for `\r\n`.
  * `self.assertLogsRegex()` doesn't seem to work for Windows for unknown reasons.
  * The Win file system doesn't allow writing to `NamedTemporaryFile`.